### PR TITLE
Using derive with raw pointers is ok now

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,6 @@
 //!     );
 //! ```
 
-#[allow(raw_pointer_derive)]
 pub mod kdtree;
 pub mod distance;
 mod heap_element;


### PR DESCRIPTION
This was raising a warning:

```
src/lib.rs:54:9: 54:27 warning: lint raw_pointer_derive has been removed: using derive with raw pointers is ok
src/lib.rs:54 #[allow(raw_pointer_derive)]
                      ^~~~~~~~~~~~~~~~~~
```