### PR TITLE
fixed clippy warnings

### DIFF
--- a/src/distance.rs
+++ b/src/distance.rs
@@ -1,7 +1,6 @@
 pub fn squared_euclidean(a: &[f64], b: &[f64]) -> f64 {
-    let mut dist = 0f64;
-    for i in 0..a.len() {
-        dist += (a[i] - b[i]) * (a[i] - b[i]);
-    }
-    return dist;
+    debug_assert!(a.len() == b.len());
+    a.iter().zip(b.iter())
+            .map(|(x, y)| (x - y) * (x - y))
+            .fold(0f64, ::std::ops::Add::add)
 }

--- a/src/heap_element.rs
+++ b/src/heap_element.rs
@@ -7,19 +7,13 @@ pub struct HeapElement<T> {
 
 impl<T> Ord for HeapElement<T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        if self.distance < other.distance {
-            return Ordering::Less;
-        } else if self.distance > other.distance {
-            return Ordering::Greater;
-        } else {
-            return Ordering::Equal;
-        }
+        self.partial_cmp(other).unwrap_or(Ordering::Equal)
     }
 }
 
 impl<T> PartialOrd for HeapElement<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
+        self.distance.partial_cmp(&other.distance)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,6 @@
 //!     );
 //! ```
 
-#[allow(raw_pointer_derive)]
 pub mod kdtree;
 pub mod distance;
 mod heap_element;


### PR DESCRIPTION
Warning: This changes the algorithms in a few places (e.g. not to use `NaN`s in `KdTree::extend(..)`). See my line notes for further information.