### PR TITLE
Fix a memory leak caused by failing to destroy the left or right nodes when KdTree is dropped

### DIFF
--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -1,4 +1,5 @@
 use std;
+use std::ops::Drop;
 use std::collections::BinaryHeap;
 use ::heap_element::HeapElement;
 use ::util;
@@ -237,3 +238,17 @@ impl<'a, T> KdTree<'a, T> {
         Ok(())
     }
 }
+
+impl<'a, T> Drop for KdTree<'a, T> {
+    fn drop(&mut self) {
+        // Clean up raw pointers by transmuting them back into boxes and allowing them to be automatically dropped
+        if let Some(left) = self.left {
+            let _: Box<KdTree<'a, T>> = unsafe { std::mem::transmute(left) };
+            self.left = None;
+        }
+        if let Some(right) = self.right {
+            let _: Box<KdTree<'a, T>> = unsafe { std::mem::transmute(right) };
+            self.right = None;
+        }
+    }
+} 

--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -205,8 +205,8 @@ impl<'a, T> KdTree<'a, T> {
                     right.add_to_bucket(point, data);
             }
         }
-        self.left = Some(unsafe {std::mem::transmute(left)});
-        self.right = Some(unsafe {std::mem::transmute(right)});
+        self.left = Some(Box::into_raw(left));
+        self.right = Some(Box::into_raw(right));
     }
 
     fn extend(&mut self, point: &[f64]) {
@@ -241,13 +241,13 @@ impl<'a, T> KdTree<'a, T> {
 
 impl<'a, T> Drop for KdTree<'a, T> {
     fn drop(&mut self) {
-        // Clean up raw pointers by transmuting them back into boxes and allowing them to be automatically dropped
+        // Clean up raw pointers by converting them back into boxes and allowing them to be automatically dropped
         if let Some(left) = self.left {
-            let _: Box<KdTree<'a, T>> = unsafe { std::mem::transmute(left) };
+            let _ = unsafe { Box::from_raw(left) };
             self.left = None;
         }
         if let Some(right) = self.right {
-            let _: Box<KdTree<'a, T>> = unsafe { std::mem::transmute(right) };
+            let _= unsafe { Box::from_raw(right) };
             self.right = None;
         }
     }

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -93,7 +93,7 @@ fn handles_singularity() {
 }
 
 #[test]
-fn drops_correctly() {
+fn handles_drops_correctly() {
     use std::ops::Drop;
     use std::sync::{ Arc, Mutex };
     
@@ -116,15 +116,13 @@ fn drops_correctly() {
     {
         // Build a kd tree
         let dimensions = 2;
-        let capacity_per_node = 2;
+        let capacity_per_node = 1;
         let mut kdtree = KdTree::new_with_capacity(dimensions, capacity_per_node);
         
         kdtree.add(&item1.0, item1.1).unwrap();
         kdtree.add(&item2.0, item2.1).unwrap();
         kdtree.add(&item3.0, item3.1).unwrap();
         kdtree.add(&item4.0, item4.1).unwrap();
-
-        assert_eq!(kdtree.size(), 4);
         
         // Pre-drop check
         assert_eq!(*drop_counter.lock().unwrap(), 0);

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -91,3 +91,45 @@ fn handles_singularity() {
     kdtree.add(&POINT_C.0, POINT_C.1).unwrap();
     assert_eq!(kdtree.size(), 9);
 }
+
+#[test]
+fn drops_correctly() {
+    use std::ops::Drop;
+    use std::sync::{ Arc, Mutex };
+    
+    // Mock up a structure to keep track of Drops
+    struct Test(Arc<Mutex<i32>>);
+    impl Drop for Test {
+        fn drop(&mut self) {
+            let mut drop_counter = self.0.lock().unwrap();
+            *drop_counter += 1;
+        }
+    }
+    
+    let drop_counter = Arc::new(Mutex::new(0));
+
+    let item1 = ([0f64, 0f64], Test(drop_counter.clone()));
+    let item2 = ([1f64, 1f64], Test(drop_counter.clone()));
+    let item3 = ([2f64, 2f64], Test(drop_counter.clone()));
+    let item4 = ([3f64, 3f64], Test(drop_counter.clone()));
+    
+    {
+        // Build a kd tree
+        let dimensions = 2;
+        let capacity_per_node = 2;
+        let mut kdtree = KdTree::new_with_capacity(dimensions, capacity_per_node);
+        
+        kdtree.add(&item1.0, item1.1).unwrap();
+        kdtree.add(&item2.0, item2.1).unwrap();
+        kdtree.add(&item3.0, item3.1).unwrap();
+        kdtree.add(&item4.0, item4.1).unwrap();
+
+        assert_eq!(kdtree.size(), 4);
+        
+        // Pre-drop check
+        assert_eq!(*drop_counter.lock().unwrap(), 0);
+    }
+    
+    // Post-drop check
+    assert_eq!(*drop_counter.lock().unwrap(), 4);
+}


### PR DESCRIPTION
Add a `std::ops::Drop` implementation for `KdTree` which converts the left and right sub tree raw pointers back into `Box<_>` and allows them to be dropped.

This PR also re-introduces `Box::into_raw` which is now stable.