### PR TITLE
Remove raw pointers and more 

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -7,18 +7,18 @@ use test::Bencher;
 use kdtree::KdTree;
 use kdtree::distance::squared_euclidean;
 
-fn rand_f64() -> f64 {
-    rand::random::<f64>()
+fn rand_data() -> ([f64; 3], f64) {
+    rand::random()
 }
 
 #[bench]
 fn bench_add_to_kdtree_with_1k_3d_points(b: &mut Bencher) {
     let len = 1000usize;
-    let point = ([rand_f64(), rand_f64(), rand_f64()], rand_f64());
+    let point = rand_data();
     let mut points = vec![];
     let mut kdtree = KdTree::new_with_capacity(3, 16);
     for _ in 0..len {
-        points.push(([rand_f64(), rand_f64(), rand_f64()], rand_f64()));
+        points.push(rand_data());
     }
     for i in 0..points.len() {
         kdtree.add(&points[i].0, points[i].1).unwrap();
@@ -29,11 +29,11 @@ fn bench_add_to_kdtree_with_1k_3d_points(b: &mut Bencher) {
 #[bench]
 fn bench_nearest_from_kdtree_with_1k_3d_points(b: &mut Bencher) {
     let len = 1000usize;
-    let point = ([rand_f64(), rand_f64(), rand_f64()], rand_f64());
+    let point = rand_data();
     let mut points = vec![];
     let mut kdtree = KdTree::new_with_capacity(3, 16);
     for _ in 0..len {
-        points.push(([rand_f64(), rand_f64(), rand_f64()], rand_f64()));
+        points.push(rand_data());
     }
     for i in 0..points.len() {
         kdtree.add(&points[i].0, points[i].1).unwrap();

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -16,11 +16,10 @@ fn bench_add_to_kdtree_with_1k_3d_points(b: &mut Bencher) {
     let len = 1000usize;
     let point = ([rand_f64(), rand_f64(), rand_f64()], rand_f64());
     let mut points = vec![];
-    let mut kdtree = KdTree::<f64>::new_with_capacity(3, 16);
+    let mut kdtree = KdTree::new_with_capacity(3, 16);
     for _ in 0..len {
         points.push(([rand_f64(), rand_f64(), rand_f64()], rand_f64()));
     }
-    let points = &points[..];
     for i in 0..points.len() {
         kdtree.add(&points[i].0, points[i].1).unwrap();
     }
@@ -32,11 +31,10 @@ fn bench_nearest_from_kdtree_with_1k_3d_points(b: &mut Bencher) {
     let len = 1000usize;
     let point = ([rand_f64(), rand_f64(), rand_f64()], rand_f64());
     let mut points = vec![];
-    let mut kdtree = KdTree::<f64>::new_with_capacity(3, 16);
+    let mut kdtree = KdTree::new_with_capacity(3, 16);
     for _ in 0..len {
         points.push(([rand_f64(), rand_f64(), rand_f64()], rand_f64()));
     }
-    let points = &points[..];
     for i in 0..points.len() {
         kdtree.add(&points[i].0, points[i].1).unwrap();
     }

--- a/src/heap_element.rs
+++ b/src/heap_element.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 pub struct HeapElement<T> {
     pub distance: f64,
-    pub element: T
+    pub element: T,
 }
 
 impl<T> Ord for HeapElement<T> {
@@ -17,11 +17,16 @@ impl<T> PartialOrd for HeapElement<T> {
     }
 }
 
-impl<T> Eq for HeapElement<T> {
-}
+impl<T> Eq for HeapElement<T> {}
 
 impl<T> PartialEq for HeapElement<T> {
     fn eq(&self, other: &Self) -> bool {
         self.distance == other.distance
+    }
+}
+
+impl<T> Into<(f64, T)> for HeapElement<T> {
+    fn into(self) -> (f64, T) {
+        (self.distance, self.element)
     }
 }

--- a/src/heap_element.rs
+++ b/src/heap_element.rs
@@ -17,11 +17,23 @@ impl<T> PartialOrd for HeapElement<T> {
     }
 }
 
+impl<T> PartialOrd<f64> for HeapElement<T> {
+    fn partial_cmp(&self, other: &f64) -> Option<Ordering> {
+        self.distance.partial_cmp(other)
+    }
+}
+
 impl<T> Eq for HeapElement<T> {}
 
 impl<T> PartialEq for HeapElement<T> {
     fn eq(&self, other: &Self) -> bool {
         self.distance == other.distance
+    }
+}
+
+impl<T> PartialEq<f64> for HeapElement<T> {
+    fn eq(&self, other: &f64) -> bool {
+        self.distance == *other
     }
 }
 

--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -30,11 +30,11 @@ pub enum ErrorKind {
 }
 
 impl<T, U: AsRef<[f64]>> KdTree<T, U> {
-    pub fn new(dims: usize) -> KdTree<T, U> {
-        KdTree::new_with_capacity(dims, 2 ^ 4)
+    pub fn new(dims: usize) -> Self {
+        KdTree::new_with_capacity(dims, 2usize.pow(4))
     }
 
-    pub fn new_with_capacity(dimensions: usize, capacity: usize) -> KdTree<T, U> {
+    pub fn new_with_capacity(dimensions: usize, capacity: usize) -> Self {
         let min_bounds = vec![std::f64::INFINITY; dimensions];
         let max_bounds = vec![std::f64::NEG_INFINITY; dimensions];
         KdTree {
@@ -70,7 +70,7 @@ impl<T, U: AsRef<[f64]>> KdTree<T, U> {
         if num <= 0 {
             return Ok(vec![]);
         }
-        let pending = &mut BinaryHeap::new();
+        let mut pending = BinaryHeap::new();
         let mut evaluated = BinaryHeap::<HeapElement<&T>>::new();
         pending.push(HeapElement {
             distance: 0f64,
@@ -79,7 +79,7 @@ impl<T, U: AsRef<[f64]>> KdTree<T, U> {
         while !pending.is_empty() &&
               (evaluated.len() < num ||
                (-pending.peek().unwrap().distance < evaluated.peek().unwrap().distance)) {
-            self.nearest_step(point, num, distance, pending, &mut evaluated);
+            self.nearest_step(point, num, distance, &mut pending, &mut evaluated);
         }
         Ok(evaluated.into_sorted_vec().into_iter().take(num).map(Into::into).collect())
     }
@@ -88,7 +88,7 @@ impl<T, U: AsRef<[f64]>> KdTree<T, U> {
                            point: &[f64],
                            num: usize,
                            distance: &F,
-                           pending: &mut BinaryHeap<HeapElement<&'b KdTree<T, U>>>,
+                           pending: &mut BinaryHeap<HeapElement<&'b Self>>,
                            evaluated: &mut BinaryHeap<HeapElement<&'b T>>)
         where F: Fn(&[f64], &[f64]) -> f64
     {

--- a/tests/count_dist.rs
+++ b/tests/count_dist.rs
@@ -1,0 +1,75 @@
+extern crate kdtree;
+
+use kdtree::KdTree;
+use kdtree::distance::squared_euclidean;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static POINT_A: ([f64; 2], usize) = ([0f64, 0f64], 0);
+static POINT_B: ([f64; 2], usize) = ([1f64, 1f64], 1);
+static POINT_C: ([f64; 2], usize) = ([2f64, 2f64], 2);
+static POINT_D: ([f64; 2], usize) = ([3f64, 3f64], 3);
+
+#[test]
+fn it_works() {
+    let dimensions = 2;
+    let capacity_per_node = 2;
+    let mut kdtree = KdTree::new_with_capacity(dimensions, capacity_per_node);
+
+    let count = AtomicUsize::new(0);
+    let new_dist = |a: &[f64], b: &[f64]| {
+        count.fetch_add(1, Ordering::SeqCst);
+        squared_euclidean(a, b)
+    };
+
+    kdtree.add(&POINT_A.0, POINT_A.1).unwrap();
+    kdtree.add(&POINT_B.0, POINT_B.1).unwrap();
+    kdtree.add(&POINT_C.0, POINT_C.1).unwrap();
+    kdtree.add(&POINT_D.0, POINT_D.1).unwrap();
+
+
+    kdtree.nearest(&POINT_A.0, 0, &new_dist).unwrap();
+    assert_eq!(0, count.swap(0, Ordering::SeqCst));
+
+    kdtree.nearest(&POINT_A.0, 1, &new_dist).unwrap();
+    assert_eq!(4, count.swap(0, Ordering::SeqCst));
+
+    kdtree.nearest(&POINT_A.0, 2, &new_dist).unwrap();
+    assert_eq!(6, count.swap(0, Ordering::SeqCst));
+
+    kdtree.nearest(&POINT_A.0, 3, &new_dist).unwrap();
+    assert_eq!(6, count.swap(0, Ordering::SeqCst));
+
+    kdtree.nearest(&POINT_A.0, 4, &new_dist).unwrap();
+    assert_eq!(6, count.swap(0, Ordering::SeqCst));
+
+    kdtree.nearest(&POINT_A.0, 5, &new_dist).unwrap();
+    assert_eq!(6, count.swap(0, Ordering::SeqCst));
+
+    kdtree.nearest(&POINT_B.0, 4, &new_dist).unwrap();
+    assert_eq!(6, count.swap(0, Ordering::SeqCst));
+
+
+    kdtree.within(&POINT_A.0, 0.0, &new_dist).unwrap();
+    assert_eq!(4, count.swap(0, Ordering::SeqCst));
+
+    kdtree.within(&POINT_B.0, 1.0, &new_dist).unwrap();
+    assert_eq!(6, count.swap(0, Ordering::SeqCst));
+
+    kdtree.within(&POINT_B.0, 2.0, &new_dist).unwrap();
+    assert_eq!(6, count.swap(0, Ordering::SeqCst));
+
+    let mut iter = kdtree.iter_nearest(&POINT_A.0, &new_dist).unwrap();
+    assert_eq!(0, count.swap(0, Ordering::SeqCst));
+
+    iter.next().unwrap();
+    assert_eq!(4, count.swap(0, Ordering::SeqCst));
+
+    iter.next().unwrap();
+    assert_eq!(2, count.swap(0, Ordering::SeqCst));
+
+    iter.next().unwrap();
+    assert_eq!(0, count.swap(0, Ordering::SeqCst));
+
+    iter.next().unwrap();
+    assert_eq!(0, count.swap(0, Ordering::SeqCst));
+}

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -38,6 +38,34 @@ fn it_works() {
 }
 
 #[test]
+fn it_works_with_vec() {
+    let dimensions = 2;
+    let capacity_per_node = 2;
+    let mut kdtree = KdTree::new_with_capacity(dimensions, capacity_per_node);
+
+    kdtree.add(vec![0.0; 2], 0).unwrap();
+    kdtree.add(vec![1.0; 2], 1).unwrap();
+    kdtree.add(vec![2.0; 2], 2).unwrap();
+    kdtree.add(vec![3.0; 2], 3).unwrap();
+
+    assert_eq!(kdtree.size(), 4);
+    assert_eq!(kdtree.nearest(&POINT_A.0, 0, &squared_euclidean).unwrap(),
+               vec![]);
+    assert_eq!(kdtree.nearest(&POINT_A.0, 1, &squared_euclidean).unwrap(),
+               vec![(0f64, &0)]);
+    assert_eq!(kdtree.nearest(&POINT_A.0, 2, &squared_euclidean).unwrap(),
+               vec![(0f64, &0), (2f64, &1)]);
+    assert_eq!(kdtree.nearest(&POINT_A.0, 3, &squared_euclidean).unwrap(),
+               vec![(0f64, &0), (2f64, &1), (8f64, &2)]);
+    assert_eq!(kdtree.nearest(&POINT_A.0, 4, &squared_euclidean).unwrap(),
+               vec![(0f64, &0), (2f64, &1), (8f64, &2), (18f64, &3)]);
+    assert_eq!(kdtree.nearest(&POINT_A.0, 5, &squared_euclidean).unwrap(),
+               vec![(0f64, &0), (2f64, &1), (8f64, &2), (18f64, &3)]);
+    assert_eq!(kdtree.nearest(&POINT_B.0, 4, &squared_euclidean).unwrap(),
+               vec![(0f64, &1), (2f64, &0), (2f64, &2), (8f64, &3)]);
+}
+
+#[test]
 fn handles_zero_capacity() {
     let mut kdtree = KdTree::new_with_capacity(2, 0);
     assert_eq!(kdtree.add(&POINT_A.0, POINT_A.1),

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -42,6 +42,9 @@ fn it_works() {
                vec![(0.0, &1)]);
     assert_eq!(kdtree.within(&POINT_B.0, 2.0, &squared_euclidean).unwrap(),
                vec![(0.0, &1), (2.0, &2), (2.0, &0)]);
+
+    assert_eq!(kdtree.iter_nearest(&POINT_A.0, &squared_euclidean).unwrap().collect::<Vec<_>>(),
+               vec![(0f64, &0), (2f64, &1), (8f64, &2), (18f64, &3)]);
 }
 
 #[test]
@@ -146,6 +149,11 @@ fn handles_pending_order() {
                vec![(16.0, &3), (36.0, &4)]);
     assert_eq!(kdtree.nearest(&[49f64], 4, &squared_euclidean).unwrap(),
                vec![(16.0, &3), (36.0, &4), (2401.0, &1), (2601.0, &2)]);
+
+    assert_eq!(kdtree.iter_nearest(&[49f64], &squared_euclidean).unwrap().collect::<Vec<_>>(),
+               vec![(16.0, &3), (36.0, &4), (2401.0, &1), (2601.0, &2)]);
+    assert_eq!(kdtree.iter_nearest(&[51f64], &squared_euclidean).unwrap().collect::<Vec<_>>(),
+               vec![(16.0, &4), (36.0, &3), (2401.0, &2), (2601.0, &1)]);
 
     assert_eq!(kdtree.within(&[50f64], 1.0, &squared_euclidean).unwrap(),
                vec![]);

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -21,49 +21,39 @@ fn it_works() {
     kdtree.add(&POINT_D.0, POINT_D.1).unwrap();
 
     assert_eq!(kdtree.size(), 4);
-    assert_eq!(
-        kdtree.nearest(&POINT_A.0, 0, &squared_euclidean).unwrap(),
-        vec![]
-    );
-    assert_eq!(
-        kdtree.nearest(&POINT_A.0, 1, &squared_euclidean).unwrap(),
-        vec![(0f64, &0)]
-    );
-    assert_eq!(
-        kdtree.nearest(&POINT_A.0, 2, &squared_euclidean).unwrap(),
-        vec![(0f64, &0), (2f64, &1)]
-    );
-    assert_eq!(
-        kdtree.nearest(&POINT_A.0, 3, &squared_euclidean).unwrap(),
-        vec![(0f64, &0), (2f64, &1), (8f64, &2)]
-    );
-    assert_eq!(
-        kdtree.nearest(&POINT_A.0, 4, &squared_euclidean).unwrap(),
-        vec![(0f64, &0), (2f64, &1), (8f64, &2), (18f64, &3)]
-    );
-    assert_eq!(
-        kdtree.nearest(&POINT_A.0, 5, &squared_euclidean).unwrap(),
-        vec![(0f64, &0), (2f64, &1), (8f64, &2), (18f64, &3)]
-    );
-    assert_eq!(
-        kdtree.nearest(&POINT_B.0, 4, &squared_euclidean).unwrap(),
-        vec![(0f64, &1), (2f64, &0), (2f64, &2), (8f64, &3)]
-    );
+    assert_eq!(kdtree.nearest(&POINT_A.0, 0, &squared_euclidean).unwrap(),
+               vec![]);
+    assert_eq!(kdtree.nearest(&POINT_A.0, 1, &squared_euclidean).unwrap(),
+               vec![(0f64, &0)]);
+    assert_eq!(kdtree.nearest(&POINT_A.0, 2, &squared_euclidean).unwrap(),
+               vec![(0f64, &0), (2f64, &1)]);
+    assert_eq!(kdtree.nearest(&POINT_A.0, 3, &squared_euclidean).unwrap(),
+               vec![(0f64, &0), (2f64, &1), (8f64, &2)]);
+    assert_eq!(kdtree.nearest(&POINT_A.0, 4, &squared_euclidean).unwrap(),
+               vec![(0f64, &0), (2f64, &1), (8f64, &2), (18f64, &3)]);
+    assert_eq!(kdtree.nearest(&POINT_A.0, 5, &squared_euclidean).unwrap(),
+               vec![(0f64, &0), (2f64, &1), (8f64, &2), (18f64, &3)]);
+    assert_eq!(kdtree.nearest(&POINT_B.0, 4, &squared_euclidean).unwrap(),
+               vec![(0f64, &1), (2f64, &0), (2f64, &2), (8f64, &3)]);
 }
 
 #[test]
 fn handles_zero_capacity() {
     let mut kdtree = KdTree::new_with_capacity(2, 0);
-    assert_eq!(kdtree.add(&POINT_A.0, POINT_A.1), Err(ErrorKind::ZeroCapacity));
-    assert_eq!(kdtree.nearest(&POINT_A.0, 1, &squared_euclidean).unwrap(), vec![]);
+    assert_eq!(kdtree.add(&POINT_A.0, POINT_A.1),
+               Err(ErrorKind::ZeroCapacity));
+    assert_eq!(kdtree.nearest(&POINT_A.0, 1, &squared_euclidean).unwrap(),
+               vec![]);
 }
 
 #[test]
 fn handles_wrong_dimension() {
     let point = ([0f64], 0f64);
     let mut kdtree = KdTree::new_with_capacity(2, 1);
-    assert_eq!(kdtree.add(&point.0, point.1), Err(ErrorKind::WrongDimension));
-    assert_eq!(kdtree.nearest(&point.0, 1, &squared_euclidean), Err(ErrorKind::WrongDimension));
+    assert_eq!(kdtree.add(&point.0, point.1),
+               Err(ErrorKind::WrongDimension));
+    assert_eq!(kdtree.nearest(&point.0, 1, &squared_euclidean),
+               Err(ErrorKind::WrongDimension));
 }
 
 #[test]
@@ -71,10 +61,14 @@ fn handles_non_finite_coordinate() {
     let point_a = ([std::f64::NAN, std::f64::NAN], 0f64);
     let point_b = ([std::f64::INFINITY, std::f64::INFINITY], 0f64);
     let mut kdtree = KdTree::new_with_capacity(2, 1);
-    assert_eq!(kdtree.add(&point_a.0, point_a.1), Err(ErrorKind::NonFiniteCoordinate));
-    assert_eq!(kdtree.add(&point_b.0, point_b.1), Err(ErrorKind::NonFiniteCoordinate));
-    assert_eq!(kdtree.nearest(&point_a.0, 1, &squared_euclidean), Err(ErrorKind::NonFiniteCoordinate));
-    assert_eq!(kdtree.nearest(&point_b.0, 1, &squared_euclidean), Err(ErrorKind::NonFiniteCoordinate));
+    assert_eq!(kdtree.add(&point_a.0, point_a.1),
+               Err(ErrorKind::NonFiniteCoordinate));
+    assert_eq!(kdtree.add(&point_b.0, point_b.1),
+               Err(ErrorKind::NonFiniteCoordinate));
+    assert_eq!(kdtree.nearest(&point_a.0, 1, &squared_euclidean),
+               Err(ErrorKind::NonFiniteCoordinate));
+    assert_eq!(kdtree.nearest(&point_b.0, 1, &squared_euclidean),
+               Err(ErrorKind::NonFiniteCoordinate));
 }
 
 #[test]
@@ -93,10 +87,37 @@ fn handles_singularity() {
 }
 
 #[test]
+fn handles_pending_order() {
+
+    let item1 = ([0f64], 1);
+    let item2 = ([100f64], 2);
+    let item3 = ([45f64], 3);
+    let item4 = ([55f64], 4);
+
+    // Build a kd tree
+    let dimensions = 1;
+    let capacity_per_node = 2;
+    let mut kdtree = KdTree::new_with_capacity(dimensions, capacity_per_node);
+
+    kdtree.add(&item1.0, item1.1).unwrap();
+    kdtree.add(&item2.0, item2.1).unwrap();
+    kdtree.add(&item3.0, item3.1).unwrap();
+    kdtree.add(&item4.0, item4.1).unwrap();
+    assert_eq!(kdtree.nearest(&[51f64], 2, &squared_euclidean).unwrap(),
+               vec![(16.0, &4), (36.0, &3)]);
+    assert_eq!(kdtree.nearest(&[51f64], 4, &squared_euclidean).unwrap(),
+               vec![(16.0, &4), (36.0, &3), (2401.0, &2), (2601.0, &1)]);
+    assert_eq!(kdtree.nearest(&[49f64], 2, &squared_euclidean).unwrap(),
+               vec![(16.0, &3), (36.0, &4)]);
+    assert_eq!(kdtree.nearest(&[49f64], 4, &squared_euclidean).unwrap(),
+               vec![(16.0, &3), (36.0, &4), (2401.0, &1), (2601.0, &2)]);
+}
+
+#[test]
 fn handles_drops_correctly() {
     use std::ops::Drop;
-    use std::sync::{ Arc, Mutex };
-    
+    use std::sync::{Arc, Mutex};
+
     // Mock up a structure to keep track of Drops
     struct Test(Arc<Mutex<i32>>);
     impl Drop for Test {
@@ -105,29 +126,29 @@ fn handles_drops_correctly() {
             *drop_counter += 1;
         }
     }
-    
+
     let drop_counter = Arc::new(Mutex::new(0));
 
     let item1 = ([0f64, 0f64], Test(drop_counter.clone()));
     let item2 = ([1f64, 1f64], Test(drop_counter.clone()));
     let item3 = ([2f64, 2f64], Test(drop_counter.clone()));
     let item4 = ([3f64, 3f64], Test(drop_counter.clone()));
-    
+
     {
         // Build a kd tree
         let dimensions = 2;
         let capacity_per_node = 1;
         let mut kdtree = KdTree::new_with_capacity(dimensions, capacity_per_node);
-        
+
         kdtree.add(&item1.0, item1.1).unwrap();
         kdtree.add(&item2.0, item2.1).unwrap();
         kdtree.add(&item3.0, item3.1).unwrap();
         kdtree.add(&item4.0, item4.1).unwrap();
-        
+
         // Pre-drop check
         assert_eq!(*drop_counter.lock().unwrap(), 0);
     }
-    
+
     // Post-drop check
     assert_eq!(*drop_counter.lock().unwrap(), 4);
 }

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -35,6 +35,13 @@ fn it_works() {
                vec![(0f64, &0), (2f64, &1), (8f64, &2), (18f64, &3)]);
     assert_eq!(kdtree.nearest(&POINT_B.0, 4, &squared_euclidean).unwrap(),
                vec![(0f64, &1), (2f64, &0), (2f64, &2), (8f64, &3)]);
+
+    assert_eq!(kdtree.within(&POINT_A.0, 0.0, &squared_euclidean).unwrap(),
+               vec![(0.0, &0)]);
+    assert_eq!(kdtree.within(&POINT_B.0, 1.0, &squared_euclidean).unwrap(),
+               vec![(0.0, &1)]);
+    assert_eq!(kdtree.within(&POINT_B.0, 2.0, &squared_euclidean).unwrap(),
+               vec![(0.0, &1), (2.0, &2), (2.0, &0)]);
 }
 
 #[test]
@@ -139,6 +146,17 @@ fn handles_pending_order() {
                vec![(16.0, &3), (36.0, &4)]);
     assert_eq!(kdtree.nearest(&[49f64], 4, &squared_euclidean).unwrap(),
                vec![(16.0, &3), (36.0, &4), (2401.0, &1), (2601.0, &2)]);
+
+    assert_eq!(kdtree.within(&[50f64], 1.0, &squared_euclidean).unwrap(),
+               vec![]);
+    assert_eq!(kdtree.within(&[50f64], 25.0, &squared_euclidean).unwrap(),
+               vec![(25.0, &3), (25.0, &4)]);
+    assert_eq!(kdtree.within(&[50f64], 30.0, &squared_euclidean).unwrap(),
+               vec![(25.0, &3), (25.0, &4)]);
+    assert_eq!(kdtree.within(&[55f64], 5.0, &squared_euclidean).unwrap(),
+               vec![(0.0, &4)]);
+    assert_eq!(kdtree.within(&[56f64], 5.0, &squared_euclidean).unwrap(),
+               vec![(1.0, &4)]);
 }
 
 #[test]


### PR DESCRIPTION
I wanted to know if this can be written in safe rust. It can!

I was having fun so I added many more things. I make it generic over the type of points being used. I added a search within a radius. I added an iterator over the points in proximity order.   

Nitpicks and suggestions welcome.   