### PR TITLE
Bug: distance_to_space on wrong thing. Massive performance wins.

### DIFF
--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -144,8 +144,10 @@ impl<T, U: AsRef<[f64]>> KdTree<T, U> {
                 candidate = curr.left.as_ref().unwrap();
                 curr = curr.right.as_ref().unwrap();
             }
-            let candidate_to_space =
-                util::distance_to_space(point, &*curr.min_bounds, &*curr.max_bounds, distance);
+            let candidate_to_space = util::distance_to_space(point,
+                                                             &*candidate.min_bounds,
+                                                             &*candidate.max_bounds,
+                                                             distance);
             if candidate_to_space <= evaluated_dist {
                 pending.push(HeapElement {
                     distance: candidate_to_space * -1f64,
@@ -158,7 +160,7 @@ impl<T, U: AsRef<[f64]>> KdTree<T, U> {
         let bucket = curr.bucket.as_ref().unwrap().iter();
         let iter = points.zip(bucket).map(|(p, d)| {
             HeapElement {
-                distance: distance(p.as_ref(), point),
+                distance: distance(point, p.as_ref()),
                 element: d,
             }
         });
@@ -339,8 +341,8 @@ impl<'a, 'b, T: 'b, U: 'b + AsRef<[f64]>, F: 'a> Iterator for NearestIter<'a, 'b
                 }
                 self.pending.push(HeapElement {
                     distance: -distance_to_space(point,
-                                                 &*curr.min_bounds,
-                                                 &*curr.max_bounds,
+                                                 &*candidate.min_bounds,
+                                                 &*candidate.max_bounds,
                                                  distance),
                     element: &**candidate,
                 });
@@ -349,7 +351,7 @@ impl<'a, 'b, T: 'b, U: 'b + AsRef<[f64]>, F: 'a> Iterator for NearestIter<'a, 'b
             let bucket = curr.bucket.as_ref().unwrap().iter();
             self.evaluated.extend(points.zip(bucket).map(|(p, d)| {
                 HeapElement {
-                    distance: -distance(p.as_ref(), point),
+                    distance: -distance(point, p.as_ref()),
                     element: d,
                 }
             }));

--- a/tests/count_dist.rs
+++ b/tests/count_dist.rs
@@ -31,10 +31,10 @@ fn it_works() {
     assert_eq!(0, count.swap(0, Ordering::SeqCst));
 
     kdtree.nearest(&POINT_A.0, 1, &new_dist).unwrap();
-    assert_eq!(4, count.swap(0, Ordering::SeqCst));
+    assert_eq!(2, count.swap(0, Ordering::SeqCst));
 
     kdtree.nearest(&POINT_A.0, 2, &new_dist).unwrap();
-    assert_eq!(6, count.swap(0, Ordering::SeqCst));
+    assert_eq!(4, count.swap(0, Ordering::SeqCst));
 
     kdtree.nearest(&POINT_A.0, 3, &new_dist).unwrap();
     assert_eq!(6, count.swap(0, Ordering::SeqCst));
@@ -50,10 +50,10 @@ fn it_works() {
 
 
     kdtree.within(&POINT_A.0, 0.0, &new_dist).unwrap();
-    assert_eq!(4, count.swap(0, Ordering::SeqCst));
+    assert_eq!(2, count.swap(0, Ordering::SeqCst));
 
     kdtree.within(&POINT_B.0, 1.0, &new_dist).unwrap();
-    assert_eq!(6, count.swap(0, Ordering::SeqCst));
+    assert_eq!(3, count.swap(0, Ordering::SeqCst));
 
     kdtree.within(&POINT_B.0, 2.0, &new_dist).unwrap();
     assert_eq!(6, count.swap(0, Ordering::SeqCst));
@@ -62,13 +62,13 @@ fn it_works() {
     assert_eq!(0, count.swap(0, Ordering::SeqCst));
 
     iter.next().unwrap();
-    assert_eq!(4, count.swap(0, Ordering::SeqCst));
+    assert_eq!(2, count.swap(0, Ordering::SeqCst));
 
     iter.next().unwrap();
     assert_eq!(2, count.swap(0, Ordering::SeqCst));
 
     iter.next().unwrap();
-    assert_eq!(0, count.swap(0, Ordering::SeqCst));
+    assert_eq!(2, count.swap(0, Ordering::SeqCst));
 
     iter.next().unwrap();
     assert_eq!(0, count.swap(0, Ordering::SeqCst));


### PR DESCRIPTION
This is big! I stumbled on this experimenting with a refactoring. 

New bench:
```
running 2 tests
test bench_add_to_kdtree_with_1k_3d_points       ... bench:         156 ns/iter (+/- 44)
test bench_nearest_from_kdtree_with_1k_3d_points ... bench:       3,603 ns/iter (+/- 3,217)
```

Old bench:
```
running 2 tests
test bench_add_to_kdtree_with_1k_3d_points       ... bench:         139 ns/iter (+/- 61)
test bench_nearest_from_kdtree_with_1k_3d_points ... bench:       6,677 ns/iter (+/- 6,613)
```

Maby evan "0.3.1"?