### PR TITLE
Add failure, derive fail for error kind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,9 @@ repository = "https://github.com/mrhooray/kdtree-rs"
 documentation = "https://docs.rs/kdtree"
 license = "MIT OR Apache-2.0"
 
+[dependencies]
+failure = "0.1"
+failure_derive = "0.1"
+
 [dev-dependencies]
 rand = "~0.3.9"

--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -23,10 +23,13 @@ pub struct KdTree<T, U: AsRef<[f64]>> {
     bucket: Option<Vec<T>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Fail, PartialEq)]
 pub enum ErrorKind {
+    #[fail(display = "Wrong dimension")]
     WrongDimension,
+    #[fail(display = "Non-finite coordinate")]
     NonFiniteCoordinate,
+    #[fail(display = "Zero capacity")]
     ZeroCapacity,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,10 @@
 //!     );
 //! ```
 
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
+
 pub mod kdtree;
 pub mod distance;
 mod heap_element;


### PR DESCRIPTION
This implements `std::error::Error` for `ErrorKind` as well.