### PR TITLE
Use generic Float trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
 rand = "0.3.9"
+
+[dependencies]
+num-traits = "0.2"

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -27,9 +27,11 @@
 /// // this is broken
 /// let _ = squared_euclidean(&[0.0, 0.0], &[1.0, 0.0, 0.0]);
 /// ```
-pub fn squared_euclidean(a: &[f64], b: &[f64]) -> f64 {
+use num_traits::Float;
+
+pub fn squared_euclidean<T: Float>(a: &[T], b: &[T]) -> T {
     debug_assert!(a.len() == b.len());
     a.iter().zip(b.iter())
-            .map(|(x, y)| (x - y) * (x - y))
-            .fold(0f64, ::std::ops::Add::add)
+            .map(|(x, y)| ((*x) - (*y)) * ((*x) - (*y)))
+            .fold(T::zero(), ::std::ops::Add::add)
 }

--- a/src/heap_element.rs
+++ b/src/heap_element.rs
@@ -1,44 +1,46 @@
+use num_traits::Float;
 use std::cmp::Ordering;
 
-pub struct HeapElement<T> {
-    pub distance: f64,
+pub struct HeapElement<A, T> {
+    pub distance: A,
     pub element: T,
 }
 
-impl<T> Ord for HeapElement<T> {
+impl<A: Float, T>  Ord for HeapElement<A, T>  {
     fn cmp(&self, other: &Self) -> Ordering {
         self.partial_cmp(other).unwrap_or(Ordering::Equal)
     }
 }
 
-impl<T> PartialOrd for HeapElement<T> {
+impl<A: Float, T>  PartialOrd for HeapElement<A, T>  {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.distance.partial_cmp(&other.distance)
     }
 }
 
-impl<T> PartialOrd<f64> for HeapElement<T> {
-    fn partial_cmp(&self, other: &f64) -> Option<Ordering> {
+impl<A: Float, T>  PartialOrd<A> for HeapElement<A, T>
+where HeapElement<A, T>: PartialEq<A> {
+    fn partial_cmp(&self, other: &A) -> Option<Ordering> {
         self.distance.partial_cmp(other)
     }
 }
 
-impl<T> Eq for HeapElement<T> {}
+impl<A: Float, T>  Eq for HeapElement<A, T>  {}
 
-impl<T> PartialEq for HeapElement<T> {
+impl<A: Float, T>  PartialEq for HeapElement<A, T>  {
     fn eq(&self, other: &Self) -> bool {
         self.distance == other.distance
     }
 }
 
-impl<T> PartialEq<f64> for HeapElement<T> {
-    fn eq(&self, other: &f64) -> bool {
+impl<A: Float, T>  PartialEq<A> for HeapElement<A, T>  {
+    fn eq(&self, other: &A) -> bool {
         self.distance == *other
     }
 }
 
-impl<T> Into<(f64, T)> for HeapElement<T> {
-    fn into(self) -> (f64, T) {
+impl<A: Float, T>  Into<(A, T)> for HeapElement<A, T>  {
+    fn into(self) -> (A, T) {
         (self.distance, self.element)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 //!     );
 //! ```
 
+extern crate num_traits;
 pub mod kdtree;
 pub mod distance;
 mod heap_element;

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,7 +22,6 @@ where F: Fn(&[T], &[T]) -> T,
 mod tests {
     use super::distance_to_space;
     use super::super::distance::squared_euclidean;
-    use num_traits::Float;
     use std::f64::{INFINITY, NEG_INFINITY};
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,10 @@
-use std;
+use num_traits::Float;
 
-pub fn distance_to_space<F> (p1: &[f64], min_bounds: &[f64], max_bounds: &[f64], distance: &F) -> f64
-where F: Fn(&[f64], &[f64]) -> f64 {
-    let mut p2 = vec![std::f64::NAN; p1.len()];
+pub fn distance_to_space<F, T> (p1: &[T], min_bounds: &[T], max_bounds: &[T], distance: &F) -> T
+where F: Fn(&[T], &[T]) -> T,
+      T: Float
+{
+    let mut p2 = vec![T::nan(); p1.len()];
     for i in 0..p1.len() {
         if p1[i] > max_bounds[i] {
             p2[i] = max_bounds[i];
@@ -20,6 +22,7 @@ where F: Fn(&[f64], &[f64]) -> f64 {
 mod tests {
     use super::distance_to_space;
     use super::super::distance::squared_euclidean;
+    use num_traits::Float;
     use std::f64::{INFINITY, NEG_INFINITY};
 
     #[test]


### PR DESCRIPTION
Hi,

This PR change the default f64 type in favor of the `Float` trait from [num-traits](https://crates.io/crates/num-traits), so it will allow to use f64 as well as f32 and should fix #12.

Don't hesitate to tell me if there is things that's need to be done in order to merge it.
Cheers!
