### PR TITLE
Add serde to support serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,14 @@ rand = "0.3.9"
 
 [dependencies]
 num-traits = "0.2"
+
+[dependencies.serde]
+version = "1.0"
+optional = true
+
+[dependencies.serde_derive]
+version = "1.0"
+optional = true
+
+[features]
+serialize = ["serde", "serde_derive"]

--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -4,6 +4,7 @@ use std::collections::BinaryHeap;
 use ::heap_element::HeapElement;
 use ::util;
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct KdTree<A, T, U: AsRef<[A]>> {
     // node

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,11 @@
 //! ```
 
 extern crate num_traits;
+
+#[cfg(feature = "serialize")]
+#[cfg_attr(feature = "serialize", macro_use)]
+extern crate serde_derive;
+
 pub mod kdtree;
 pub mod distance;
 mod heap_element;


### PR DESCRIPTION
I have a project encoding location data into a kdtree. Because all the fields are private it is a hassle to add getters for all of them.  Supporting serde here would be a lot more convenient.