### PR TITLE
Rename `KdTree::new_with_capacity()` to `with_capcity()`

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -16,7 +16,7 @@ fn bench_add_to_kdtree_with_1k_3d_points(b: &mut Bencher) {
     let len = 1000usize;
     let point = rand_data();
     let mut points = vec![];
-    let mut kdtree = KdTree::new_with_capacity(3, 16);
+    let mut kdtree = KdTree::with_capacity(3, 16);
     for _ in 0..len {
         points.push(rand_data());
     }
@@ -31,7 +31,7 @@ fn bench_nearest_from_kdtree_with_1k_3d_points(b: &mut Bencher) {
     let len = 1000usize;
     let point = rand_data();
     let mut points = vec![];
-    let mut kdtree = KdTree::new_with_capacity(3, 16);
+    let mut kdtree = KdTree::with_capacity(3, 16);
     for _ in 0..len {
         points.push(rand_data());
     }

--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -34,10 +34,10 @@ pub enum ErrorKind {
 
 impl<A: Float + Zero + One, T, U: AsRef<[A]>> KdTree<A, T, U> {
     pub fn new(dims: usize) -> Self {
-        KdTree::new_with_capacity(dims, 2usize.pow(4))
+        KdTree::with_capacity(dims, 2_usize.pow(4))
     }
 
-    pub fn new_with_capacity(dimensions: usize, capacity: usize) -> Self {
+    pub fn with_capacity(dimensions: usize, capacity: usize) -> Self {
         let min_bounds = vec![A::infinity(); dimensions];
         let max_bounds = vec![A::neg_infinity(); dimensions];
         KdTree {
@@ -284,8 +284,8 @@ impl<A: Float + Zero + One, T, U: AsRef<[A]>> KdTree<A, T, U> {
                 self.split_value = Some(min + (max - min) / A::from(2.0).unwrap());
             }
         };
-        let mut left = Box::new(KdTree::new_with_capacity(self.dimensions, self.capacity));
-        let mut right = Box::new(KdTree::new_with_capacity(self.dimensions, self.capacity));
+        let mut left = Box::new(KdTree::with_capacity(self.dimensions, self.capacity));
+        let mut right = Box::new(KdTree::with_capacity(self.dimensions, self.capacity));
         while !points.is_empty() {
             let point = points.swap_remove(0);
             let data = bucket.swap_remove(0);
@@ -453,7 +453,7 @@ mod tests {
 
     #[test]
     fn no_items_can_be_added_to_a_zero_capacity_kdtree() {
-        let mut tree: KdTree<f64, i32, [f64; 2]> = KdTree::new_with_capacity(2, 0);
+        let mut tree: KdTree<f64, i32, [f64; 2]> = KdTree::with_capacity(2, 0);
         let (pos, data) = random_point();
         let res = tree.add(pos, data);
         assert!(res.is_err());

--- a/tests/count_dist.rs
+++ b/tests/count_dist.rs
@@ -13,7 +13,7 @@ static POINT_D: ([f64; 2], usize) = ([3f64, 3f64], 3);
 fn it_works() {
     let dimensions = 2;
     let capacity_per_node = 2;
-    let mut kdtree = KdTree::new_with_capacity(dimensions, capacity_per_node);
+    let mut kdtree = KdTree::with_capacity(dimensions, capacity_per_node);
 
     let count = AtomicUsize::new(0);
     let new_dist = |a: &[f64], b: &[f64]| {

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -13,7 +13,7 @@ static POINT_D: ([f64; 2], usize) = ([3f64, 3f64], 3);
 fn it_works() {
     let dimensions = 2;
     let capacity_per_node = 2;
-    let mut kdtree = KdTree::new_with_capacity(dimensions, capacity_per_node);
+    let mut kdtree = KdTree::with_capacity(dimensions, capacity_per_node);
 
     kdtree.add(&POINT_A.0, POINT_A.1).unwrap();
     kdtree.add(&POINT_B.0, POINT_B.1).unwrap();
@@ -76,7 +76,7 @@ fn it_works() {
 fn it_works_with_vec() {
     let dimensions = 2;
     let capacity_per_node = 2;
-    let mut kdtree = KdTree::new_with_capacity(dimensions, capacity_per_node);
+    let mut kdtree = KdTree::with_capacity(dimensions, capacity_per_node);
 
     kdtree.add(vec![0.0; 2], 0).unwrap();
     kdtree.add(vec![1.0; 2], 1).unwrap();
@@ -116,7 +116,8 @@ fn it_works_with_vec() {
 
 #[test]
 fn handles_zero_capacity() {
-    let mut kdtree = KdTree::new_with_capacity(2, 0);
+    let mut kdtree = KdTree::with_capacity(2, 0);
+
     assert_eq!(
         kdtree.add(&POINT_A.0, POINT_A.1),
         Err(ErrorKind::ZeroCapacity)
@@ -130,7 +131,8 @@ fn handles_zero_capacity() {
 #[test]
 fn handles_wrong_dimension() {
     let point = ([0f64], 0f64);
-    let mut kdtree = KdTree::new_with_capacity(2, 1);
+    let mut kdtree = KdTree::with_capacity(2, 1);
+
     assert_eq!(
         kdtree.add(&point.0, point.1),
         Err(ErrorKind::WrongDimension)
@@ -145,7 +147,8 @@ fn handles_wrong_dimension() {
 fn handles_non_finite_coordinate() {
     let point_a = ([std::f64::NAN, std::f64::NAN], 0f64);
     let point_b = ([std::f64::INFINITY, std::f64::INFINITY], 0f64);
-    let mut kdtree = KdTree::new_with_capacity(2, 1);
+    let mut kdtree = KdTree::with_capacity(2, 1);
+
     assert_eq!(
         kdtree.add(&point_a.0, point_a.1),
         Err(ErrorKind::NonFiniteCoordinate)
@@ -166,7 +169,7 @@ fn handles_non_finite_coordinate() {
 
 #[test]
 fn handles_singularity() {
-    let mut kdtree = KdTree::new_with_capacity(2, 1);
+    let mut kdtree = KdTree::with_capacity(2, 1);
     kdtree.add(&POINT_A.0, POINT_A.1).unwrap();
     kdtree.add(&POINT_A.0, POINT_A.1).unwrap();
     kdtree.add(&POINT_A.0, POINT_A.1).unwrap();
@@ -189,7 +192,7 @@ fn handles_pending_order() {
     // Build a kd tree
     let dimensions = 1;
     let capacity_per_node = 2;
-    let mut kdtree = KdTree::new_with_capacity(dimensions, capacity_per_node);
+    let mut kdtree = KdTree::with_capacity(dimensions, capacity_per_node);
 
     kdtree.add(&item1.0, item1.1).unwrap();
     kdtree.add(&item2.0, item2.1).unwrap();
@@ -274,7 +277,7 @@ fn handles_drops_correctly() {
         // Build a kd tree
         let dimensions = 2;
         let capacity_per_node = 1;
-        let mut kdtree = KdTree::new_with_capacity(dimensions, capacity_per_node);
+        let mut kdtree = KdTree::with_capacity(dimensions, capacity_per_node);
 
         kdtree.add(&item1.0, item1.1).unwrap();
         kdtree.add(&item2.0, item2.1).unwrap();


### PR DESCRIPTION
Rename `KdTree::new_with_capacity()` to `with_capcity()`, which follows [Rust naming convention](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html).