### PR TITLE
Add docs to constructors

### DIFF
--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -7,7 +7,7 @@ use crate::util;
 
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
-pub struct KdTree<A, T: std::cmp::PartialEq, U: AsRef<[A]>+ std::cmp::PartialEq> {
+pub struct KdTree<A, T: std::cmp::PartialEq, U: AsRef<[A]> + std::cmp::PartialEq> {
     // node
     left: Option<Box<KdTree<A, T, U>>>,
     right: Option<Box<KdTree<A, T, U>>>,
@@ -32,11 +32,16 @@ pub enum ErrorKind {
     ZeroCapacity,
 }
 
-impl<A: Float + Zero + One, T: std::cmp::PartialEq, U: AsRef<[A]> + std::cmp::PartialEq> KdTree<A, T, U> {
+impl<A: Float + Zero + One, T: std::cmp::PartialEq, U: AsRef<[A]> + std::cmp::PartialEq>
+    KdTree<A, T, U>
+{
+    /// Create a new KD tree, specifying the dimension size of each point
     pub fn new(dims: usize) -> Self {
         KdTree::with_capacity(dims, 2_usize.pow(4))
     }
 
+    /// Create a new KD tree, specifying the dimension size of each point and the capacity of leaf
+    /// nodes, which must not be 0.
     pub fn with_capacity(dimensions: usize, capacity: usize) -> Self {
         let min_bounds = vec![A::infinity(); dimensions];
         let max_bounds = vec![A::neg_infinity(); dimensions];
@@ -415,7 +420,9 @@ pub struct NearestIter<
 impl<'a, 'b, A: Float + Zero + One, T: 'b, U: 'b + AsRef<[A]>, F: 'a> Iterator
     for NearestIter<'a, 'b, A, T, U, F>
 where
-    F: Fn(&[A], &[A]) -> A, U: PartialEq, T: PartialEq
+    F: Fn(&[A], &[A]) -> A,
+    U: PartialEq,
+    T: PartialEq,
 {
     type Item = (A, &'b T);
     fn next(&mut self) -> Option<(A, &'b T)> {
@@ -476,7 +483,9 @@ pub struct NearestIterMut<
 impl<'a, 'b, A: Float + Zero + One, T: 'b, U: 'b + AsRef<[A]>, F: 'a> Iterator
     for NearestIterMut<'a, 'b, A, T, U, F>
 where
-    F: Fn(&[A], &[A]) -> A, U: PartialEq, T: PartialEq
+    F: Fn(&[A], &[A]) -> A,
+    U: PartialEq,
+    T: PartialEq,
 {
     type Item = (A, &'b mut T);
     fn next(&mut self) -> Option<(A, &'b mut T)> {

--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -32,16 +32,14 @@ pub enum ErrorKind {
     ZeroCapacity,
 }
 
-impl<A: Float + Zero + One, T: std::cmp::PartialEq, U: AsRef<[A]> + std::cmp::PartialEq>
-    KdTree<A, T, U>
+impl<A: Float + Zero + One, T: std::cmp::PartialEq, U: AsRef<[A]> + std::cmp::PartialEq> KdTree<A, T, U>
 {
     /// Create a new KD tree, specifying the dimension size of each point
     pub fn new(dims: usize) -> Self {
         KdTree::with_capacity(dims, 2_usize.pow(4))
     }
 
-    /// Create a new KD tree, specifying the dimension size of each point and the capacity of leaf
-    /// nodes, which must not be 0.
+    /// Create a new KD tree, specifying the dimension size of each point and the capacity of leaf nodes
     pub fn with_capacity(dimensions: usize, capacity: usize) -> Self {
         let min_bounds = vec![A::infinity(); dimensions];
         let max_bounds = vec![A::neg_infinity(); dimensions];

--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -32,8 +32,7 @@ pub enum ErrorKind {
     ZeroCapacity,
 }
 
-impl<A: Float + Zero + One, T: std::cmp::PartialEq, U: AsRef<[A]> + std::cmp::PartialEq> KdTree<A, T, U>
-{
+impl<A: Float + Zero + One, T: std::cmp::PartialEq, U: AsRef<[A]> + std::cmp::PartialEq> KdTree<A, T, U> {
     /// Create a new KD tree, specifying the dimension size of each point
     pub fn new(dims: usize) -> Self {
         KdTree::with_capacity(dims, 2_usize.pow(4))


### PR DESCRIPTION
Add some simple docs to constructors, along with some formatting changes. The most important part is clarifying that `capacity` refers to the capacity of the leaf nodes, not the entire tree.