### PR TITLE
added within_unsorted and within_count

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -40,3 +40,111 @@ fn bench_nearest_from_kdtree_with_1k_3d_points(b: &mut Bencher) {
     }
     b.iter(|| kdtree.nearest(&point.0, 8, &squared_euclidean).unwrap());
 }
+
+#[bench]
+fn bench_within_2k_data_01_radius(b: &mut Bencher) {
+
+    let len = 2000usize;
+    let point = rand_data();
+    let mut points = vec![];
+    let mut kdtree = KdTree::with_capacity(3, 16);
+    for _ in 0..len {
+        points.push(rand_data());
+    }
+    for i in 0..points.len() {
+        kdtree.add(&points[i].0, points[i].1).unwrap();
+    }
+
+    b.iter(|| kdtree.within(&point.0, 0.1, &squared_euclidean).unwrap());
+
+}
+
+#[bench]
+fn bench_within_2k_data_02_radius(b: &mut Bencher) {
+
+    let len = 2000usize;
+    let point = rand_data();
+    let mut points = vec![];
+    let mut kdtree = KdTree::with_capacity(3, 16);
+    for _ in 0..len {
+        points.push(rand_data());
+    }
+    for i in 0..points.len() {
+        kdtree.add(&points[i].0, points[i].1).unwrap();
+    }
+
+    b.iter(|| kdtree.within(&point.0, 0.2, &squared_euclidean).unwrap());
+
+}
+
+#[bench]
+fn bench_within_unsorted_2k_data_01_radius(b: &mut Bencher) {
+
+    let len = 2000usize;
+    let point = rand_data();
+    let mut points = vec![];
+    let mut kdtree = KdTree::with_capacity(3, 16);
+    for _ in 0..len {
+        points.push(rand_data());
+    }
+    for i in 0..points.len() {
+        kdtree.add(&points[i].0, points[i].1).unwrap();
+    }
+
+    b.iter(|| kdtree.within_unsorted(&point.0, 0.1, &squared_euclidean).unwrap());
+
+}
+
+#[bench]
+fn bench_within_unsorted_2k_data_02_radius(b: &mut Bencher) {
+
+    let len = 2000usize;
+    let point = rand_data();
+    let mut points = vec![];
+    let mut kdtree = KdTree::with_capacity(3, 16);
+    for _ in 0..len {
+        points.push(rand_data());
+    }
+    for i in 0..points.len() {
+        kdtree.add(&points[i].0, points[i].1).unwrap();
+    }
+
+    b.iter(|| kdtree.within_unsorted(&point.0, 0.2, &squared_euclidean).unwrap());
+
+}
+
+#[bench]
+fn bench_within_count_2k_data_01_radius(b: &mut Bencher) {
+
+    let len = 2000usize;
+    let point = rand_data();
+    let mut points = vec![];
+    let mut kdtree = KdTree::with_capacity(3, 16);
+    for _ in 0..len {
+        points.push(rand_data());
+    }
+    for i in 0..points.len() {
+        kdtree.add(&points[i].0, points[i].1).unwrap();
+    }
+
+    b.iter(|| kdtree.within_count(&point.0, 0.1, &squared_euclidean).unwrap());
+
+}
+
+#[bench]
+fn bench_within_count_2k_data_02_radius(b: &mut Bencher) {
+
+    let len = 2000usize;
+    let point = rand_data();
+    let mut points = vec![];
+    let mut kdtree = KdTree::with_capacity(3, 16);
+    for _ in 0..len {
+        points.push(rand_data());
+    }
+    for i in 0..points.len() {
+        kdtree.add(&points[i].0, points[i].1).unwrap();
+    }
+
+    b.iter(|| kdtree.within_count(&point.0, 0.2, &squared_euclidean).unwrap());
+
+}

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -43,7 +43,6 @@ fn bench_nearest_from_kdtree_with_1k_3d_points(b: &mut Bencher) {
 
 #[bench]
 fn bench_within_2k_data_01_radius(b: &mut Bencher) {
-
     let len = 2000usize;
     let point = rand_data();
     let mut points = vec![];
@@ -56,12 +55,10 @@ fn bench_within_2k_data_01_radius(b: &mut Bencher) {
     }
 
     b.iter(|| kdtree.within(&point.0, 0.1, &squared_euclidean).unwrap());
-
 }
 
 #[bench]
 fn bench_within_2k_data_02_radius(b: &mut Bencher) {
-
     let len = 2000usize;
     let point = rand_data();
     let mut points = vec![];
@@ -74,12 +71,10 @@ fn bench_within_2k_data_02_radius(b: &mut Bencher) {
     }
 
     b.iter(|| kdtree.within(&point.0, 0.2, &squared_euclidean).unwrap());
-
 }
 
 #[bench]
 fn bench_within_unsorted_2k_data_01_radius(b: &mut Bencher) {
-
     let len = 2000usize;
     let point = rand_data();
     let mut points = vec![];
@@ -92,12 +87,10 @@ fn bench_within_unsorted_2k_data_01_radius(b: &mut Bencher) {
     }
 
     b.iter(|| kdtree.within_unsorted(&point.0, 0.1, &squared_euclidean).unwrap());
-
 }
 
 #[bench]
 fn bench_within_unsorted_2k_data_02_radius(b: &mut Bencher) {
-
     let len = 2000usize;
     let point = rand_data();
     let mut points = vec![];
@@ -110,12 +103,10 @@ fn bench_within_unsorted_2k_data_02_radius(b: &mut Bencher) {
     }
 
     b.iter(|| kdtree.within_unsorted(&point.0, 0.2, &squared_euclidean).unwrap());
-
 }
 
 #[bench]
 fn bench_within_count_2k_data_01_radius(b: &mut Bencher) {
-
     let len = 2000usize;
     let point = rand_data();
     let mut points = vec![];
@@ -128,12 +119,10 @@ fn bench_within_count_2k_data_01_radius(b: &mut Bencher) {
     }
 
     b.iter(|| kdtree.within_count(&point.0, 0.1, &squared_euclidean).unwrap());
-
 }
 
 #[bench]
 fn bench_within_count_2k_data_02_radius(b: &mut Bencher) {
-
     let len = 2000usize;
     let point = rand_data();
     let mut points = vec![];
@@ -146,5 +135,4 @@ fn bench_within_count_2k_data_02_radius(b: &mut Bencher) {
     }
 
     b.iter(|| kdtree.within_count(&point.0, 0.2, &squared_euclidean).unwrap());
-
 }

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -62,10 +62,7 @@ fn it_works() {
 
     let unsorted1 = kdtree.within_unsorted(&POINT_A.0, 0.0, &squared_euclidean).unwrap();
     let ans1 = vec![(0.0, &0)];
-    assert_eq!(
-        unsorted1.len(),
-        ans1.len()
-    );
+    assert_eq!(unsorted1.len(), ans1.len());
     assert_eq!(
         kdtree.within_count(&POINT_A.0, 0.0, &squared_euclidean).unwrap(),
         ans1.len()
@@ -76,10 +73,7 @@ fn it_works() {
 
     let unsorted2 = kdtree.within_unsorted(&POINT_B.0, 1.0, &squared_euclidean).unwrap();
     let ans2 = vec![(0.0, &1)];
-    assert_eq!(
-        unsorted2.len(),
-        ans2.len()
-    );
+    assert_eq!(unsorted2.len(), ans2.len());
     assert_eq!(
         kdtree.within_count(&POINT_B.0, 1.0, &squared_euclidean).unwrap(),
         ans2.len()
@@ -90,10 +84,7 @@ fn it_works() {
 
     let unsorted3 = kdtree.within_unsorted(&POINT_B.0, 2.0, &squared_euclidean).unwrap();
     let ans3 = vec![(0.0, &1), (2.0, &2), (2.0, &0)];
-    assert_eq!(
-        unsorted3.len(),
-        ans3.len()
-    );
+    assert_eq!(unsorted3.len(), ans3.len());
     assert_eq!(
         kdtree.within_count(&POINT_B.0, 2.0, &squared_euclidean).unwrap(),
         ans3.len()

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -60,6 +60,48 @@ fn it_works() {
         vec![(0.0, &1), (2.0, &2), (2.0, &0)]
     );
 
+    let unsorted1 = kdtree.within_unsorted(&POINT_A.0, 0.0, &squared_euclidean).unwrap();
+    let ans1 = vec![(0.0, &0)];
+    assert_eq!(
+        unsorted1.len(),
+        ans1.len()
+    );
+    assert_eq!(
+        kdtree.within_count(&POINT_A.0, 0.0, &squared_euclidean).unwrap(),
+        ans1.len()
+    );
+    for item in unsorted1 {
+        assert!(ans1.contains(&item));
+    }
+
+    let unsorted2 = kdtree.within_unsorted(&POINT_B.0, 1.0, &squared_euclidean).unwrap();
+    let ans2 = vec![(0.0, &1)];
+    assert_eq!(
+        unsorted2.len(),
+        ans2.len()
+    );
+    assert_eq!(
+        kdtree.within_count(&POINT_B.0, 1.0, &squared_euclidean).unwrap(),
+        ans2.len()
+    );
+    for item in unsorted2 {
+        assert!(ans2.contains(&item));
+    }
+
+    let unsorted3 = kdtree.within_unsorted(&POINT_B.0, 2.0, &squared_euclidean).unwrap();
+    let ans3 = vec![(0.0, &1), (2.0, &2), (2.0, &0)];
+    assert_eq!(
+        unsorted3.len(),
+        ans3.len()
+    );
+    assert_eq!(
+        kdtree.within_count(&POINT_B.0, 2.0, &squared_euclidean).unwrap(),
+        ans3.len()
+    );
+    for item in unsorted3 {
+        assert!(ans3.contains(&item));
+    }
+
     assert_eq!(
         kdtree
             .iter_nearest(&POINT_A.0, &squared_euclidean)


### PR DESCRIPTION
In some scientific computing tasks, we only need the neighbors within radius (with no requirement on being ordered), and there is no need to sort them, or we only need the neighbor count. 

I implemented within_unsorted and within_count to deal with these situations more efficiently.

**To check:**
run tests and bench

![image](https://github.com/mrhooray/kdtree-rs/assets/72534736/ae08a262-f7d2-424a-97b9-82dc7eb11dd1)
