### PR TITLE
Working with no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ license = "MIT OR Apache-2.0"
 [dev-dependencies]
 rand = "0.8.5"
 
-[dependencies]
-num-traits = "0.2"
-thiserror = "1.0"
+[dependencies.num-traits]
+version = "0.2"
+default-features = false
 
 [dependencies.serde]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rand = "0.8.5"
 [dependencies.num-traits]
 version = "0.2"
 default-features = false
+features = ["libm"]
 
 [dependencies.serde]
 version = "1.0"
@@ -26,3 +27,4 @@ optional = true
 
 [features]
 serialize = ["serde", "serde_derive"]
+std = []

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -34,5 +34,5 @@ pub fn squared_euclidean<T: Float>(a: &[T], b: &[T]) -> T {
     a.iter()
         .zip(b.iter())
         .map(|(x, y)| ((*x) - (*y)) * ((*x) - (*y)))
-        .fold(T::zero(), ::std::ops::Add::add)
+        .fold(T::zero(), core::ops::Add::add)
 }

--- a/src/heap_element.rs
+++ b/src/heap_element.rs
@@ -1,5 +1,5 @@
 use num_traits::Float;
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 pub struct HeapElement<A, T> {
     pub distance: A,

--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -3,7 +3,9 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use num_traits::{Float, One, Zero};
-// use thiserror::Error;
+
+#[cfg(feature = "std")]
+use thiserror::Error;
 
 use crate::heap_element::HeapElement;
 use crate::util;
@@ -30,11 +32,11 @@ pub struct KdTree<A, T: core::cmp::PartialEq, U: AsRef<[A]> + core::cmp::Partial
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ErrorKind {
-    // #[error("wrong dimension")]
+    #[cfg_attr(feature = "std", error("wrong dimension"))]
     WrongDimension,
-    // #[error("non-finite coordinate")]
+    #[cfg_attr(feature = "std", error("non-finite coordinate"))]
     NonFiniteCoordinate,
-    // #[error("zero capacity")]
+    #[cfg_attr(feature = "std", error("zero capacity"))]
     ZeroCapacity,
 }
 

--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -1,14 +1,16 @@
-use std::collections::BinaryHeap;
+use alloc::collections::BinaryHeap;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use num_traits::{Float, One, Zero};
-use thiserror::Error;
+// use thiserror::Error;
 
 use crate::heap_element::HeapElement;
 use crate::util;
 
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
-pub struct KdTree<A, T: std::cmp::PartialEq, U: AsRef<[A]> + std::cmp::PartialEq> {
+pub struct KdTree<A, T: core::cmp::PartialEq, U: AsRef<[A]> + core::cmp::PartialEq> {
     // node
     left: Option<Box<KdTree<A, T, U>>>,
     right: Option<Box<KdTree<A, T, U>>>,
@@ -26,17 +28,17 @@ pub struct KdTree<A, T: std::cmp::PartialEq, U: AsRef<[A]> + std::cmp::PartialEq
     bucket: Option<Vec<T>>,
 }
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ErrorKind {
-    #[error("wrong dimension")]
+    // #[error("wrong dimension")]
     WrongDimension,
-    #[error("non-finite coordinate")]
+    // #[error("non-finite coordinate")]
     NonFiniteCoordinate,
-    #[error("zero capacity")]
+    // #[error("zero capacity")]
     ZeroCapacity,
 }
 
-impl<A: Float + Zero + One, T: std::cmp::PartialEq, U: AsRef<[A]> + std::cmp::PartialEq> KdTree<A, T, U> {
+impl<A: Float + Zero + One, T: core::cmp::PartialEq, U: AsRef<[A]> + core::cmp::PartialEq> KdTree<A, T, U> {
     /// Create a new KD tree, specifying the dimension size of each point
     pub fn new(dims: usize) -> Self {
         KdTree::with_capacity(dims, 2_usize.pow(4))
@@ -70,7 +72,7 @@ impl<A: Float + Zero + One, T: std::cmp::PartialEq, U: AsRef<[A]> + std::cmp::Pa
         F: Fn(&[A], &[A]) -> A,
     {
         self.check_point(point)?;
-        let num = std::cmp::min(num, self.size);
+        let num = core::cmp::min(num, self.size);
         if num == 0 {
             return Ok(vec![]);
         }
@@ -406,7 +408,7 @@ pub struct NearestIter<
     'b,
     A: 'a + 'b + Float,
     T: 'b + PartialEq,
-    U: 'b + AsRef<[A]> + std::cmp::PartialEq,
+    U: 'b + AsRef<[A]> + core::cmp::PartialEq,
     F: 'a + Fn(&[A], &[A]) -> A,
 > {
     point: &'a [A],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,14 @@
 //!     vec![(0f64, &1), (2f64, &0), (2f64, &2), (8f64, &3)]
 //! );
 //! ```
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
 extern crate num_traits;
-extern crate thiserror;
+// extern crate thiserror;
 
 #[cfg(feature = "serialize")]
 #[cfg_attr(feature = "serialize", macro_use)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,9 @@
 extern crate alloc;
 
 extern crate num_traits;
-// extern crate thiserror;
+
+#[cfg(feature = "std")]
+extern crate thiserror;
 
 #[cfg(feature = "serialize")]
 #[cfg_attr(feature = "serialize", macro_use)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,7 +22,7 @@ where
 mod tests {
     use super::distance_to_space;
     use crate::distance::squared_euclidean;
-    use std::f64::{INFINITY, NEG_INFINITY};
+    use core::f64::{INFINITY, NEG_INFINITY};
 
     #[test]
     fn test_normal_distance_to_space() {


### PR DESCRIPTION
I found that kdtree-rs can be used for development of robot localization algorithms on edge devices, so I made this crate compatible with no-std.

The main modification was to replace std functions with the ones in the core crate. The `thiserror` crate seems only available on std, so it will be disabled on no-std. 

I did this modification just for my use case. If this PR is not necessary for you, feel free to close without merge. 